### PR TITLE
Craft 5.x & Commerce 5.x Support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 # Click & Collect for Craft Commerce 2.0.0 - 2025-03-05
 
-Adds Craft CMS 5.x Support
+Adds Craft CMS 5.x and Commerce 5.x Support
+
+OrderService changes:
 
 | Deprecation                           | Reason                                                 |
 | ------------------------------------- | ------------------------------------------------------ |
@@ -11,6 +13,7 @@ Adds Craft CMS 5.x Support
 | OrderService::createTab() Updated     | Tabs are still part of Field Layouts so they are kept. |
 | OrderService::addFieldToTab() Updated | This has been adjusted to work without Field Groups.   |
 
+ClickAndCollectShippingRule updated to use `craft\commerce\models\ShippingRule`. Stricter type hints implemented.
 
 # Click & Collect for Craft Commerce 1.0.1 - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release notes for Click & Collect for Craft Commerce
 
+# Click & Collect for Craft Commerce 2.0.0 - 2025-03-05
+
+Adds Craft CMS 5.x Support
+
+| Deprecation                           | Reason                                                 |
+| ------------------------------------- | ------------------------------------------------------ |
+| OrderService::createGroup() Removed   | Field Groups no longer exist in Craft 5.               |
+| OrderService::createField() Updated   | Fields are created without groups.                     |
+| OrderService::createTab() Updated     | Tabs are still part of Field Layouts so they are kept. |
+| OrderService::addFieldToTab() Updated | This has been adjusted to work without Field Groups.   |
+
+
 # Click & Collect for Craft Commerce 1.0.1 - 2024-11-20
 
 Bug Fixes & Functionality Improvements

--- a/README.md
+++ b/README.md
@@ -6,11 +6,20 @@ Click & Collect for Craft Commerce adds drop in Click and Collect functionality 
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0.0 or later.
-This plugin requires Craft Commerce 4.6.0 or later.
-This plugin requires PHP 8.0 or later.
+This plugin requires Craft CMS 5.6.0 or later.
+This plugin requires Craft Commerce 5.3.4 or later.
+This plugin requires PHP 8.2 or later.
 
 https://github.com/user-attachments/assets/5ef784b5-4f44-4ee2-b3fc-0513100a5c68
+
+> {note} Craft Commerce must be 5.3.4 or later due to [a bug in previous versions of Commerce 5 impacting registration of custom shipping methods.](https://github.com/craftcms/commerce/commit/b769a1d2541ba14dccd974d863a13e2b479a6ca8)
+
+## Compatibility & Previous Versions
+
+| Click & Collect for Craft Commerce  | Craft 4            | Craft 5            |
+|-------------------------------------|--------------------|--------------------|
+| 1.x                                 | :white_check_mark: | :x:                |
+| 2.x                                 | :x:                | :white_check_mark: |
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "burnthebook/craft-commerce-click-and-collect",
   "description": "A Craft Commerce plugin enabling Click & Collect functionality.",
   "type": "craft-plugin",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "keywords": [
     "craft",
     "cms",
@@ -29,8 +29,8 @@
     "docs": "https://github.com/burnthebook/craft-commerce-click-and-collect/blob/main/README.md"
   },
   "require": {
-    "craftcms/cms": "^4.0",
-    "craftcms/commerce": "^4.6"
+    "craftcms/cms": "^5.0",
+    "craftcms/commerce": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/services/OrderService.php
+++ b/src/services/OrderService.php
@@ -5,7 +5,6 @@ namespace burnthebook\craftcommerceclickandcollect\services;
 use Craft;
 use craft\base\Component;
 use craft\fields\PlainText;
-use craft\models\FieldGroup;
 use craft\commerce\elements\Order;
 use craft\models\FieldLayoutTab;
 use craft\models\FieldLayout;
@@ -14,51 +13,19 @@ use craft\fieldlayoutelements\CustomField;
 class OrderService extends Component
 {
     /**
-     * Creates fields for the "Click & Collect" group and tab in the order layout.
+     * Creates the necessary fields and adds them to the order layout.
      *
      * @return void
     */
     public function createFields()
     {
-        // Create or retrieve the group
-        $fieldGroup = $this->createGroup('Click & Collect');
-
         // Ensure the "Click & Collect" tab exists in the order layout
         $clickAndCollectTab = $this->createTab('Click & Collect', Order::class);
 
-        // Create fields
-        $this->createField('mobileNumber', 'Mobile Number', 'Customer mobile number for contact.', $fieldGroup, $clickAndCollectTab);
-        $this->createField('collectionPoint', 'Collection Point', 'Customer collection point.', $fieldGroup, $clickAndCollectTab);
-        $this->createField('collectionTime', 'Collection Time', 'Customer collection time.', $fieldGroup, $clickAndCollectTab);
-    }
-
-    /**
-     * Creates a new field group with the given name, or returns an existing group with the same name.
-     *
-     * @param string $groupName The name of the field group to create.
-     * @return FieldGroup|false The newly created field group, or false if there was an error.
-    */
-    private function createGroup($groupName)
-    {
-        $fieldsService = Craft::$app->getFields();
-        $allGroups = $fieldsService->getAllGroups();
-
-        // Search for the group by name
-        foreach ($allGroups as $group) {
-            if ($group->name === $groupName) {
-                return $group;
-            }
-        }
-
-        // Create the group if it doesn't exist
-        $fieldGroup = new FieldGroup();
-        $fieldGroup->name = $groupName;
-        if (!$fieldsService->saveGroup($fieldGroup)) {
-            Craft::error('Could not save the field group. Errors: ' . print_r($fieldGroup->getErrors(), true), __METHOD__);
-            return false;
-        }
-
-        return $fieldGroup;
+        // Create fields (NO GROUPS REQUIRED)
+        $this->createField('mobileNumber', 'Mobile Number', 'Customer mobile number for contact.', $clickAndCollectTab);
+        $this->createField('collectionPoint', 'Collection Point', 'Customer collection point.', $clickAndCollectTab);
+        $this->createField('collectionTime', 'Collection Time', 'Customer collection time.', $clickAndCollectTab);
     }
 
     /**
@@ -100,16 +67,15 @@ class OrderService extends Component
     }
 
     /**
-     * Creates a new field with the given handle suffix, name, instructions, field group, and tab.
+     * Creates a new field and assigns it to a tab.
      *
      * @param string $handleSuffix The suffix to use for the field handle.
      * @param string $name The name of the field.
      * @param string $instructions The instructions for the field.
-     * @param FieldGroup $fieldGroup The field group to add the field to.
-     * @param Tab $tab The tab to add the field to.
+     * @param FieldLayoutTab $tab The tab to add the field to.
      * @return bool Whether the field was successfully created and added to the tab.
     */
-    private function createField($handleSuffix, $name, $instructions, $fieldGroup, $tab)
+    private function createField($handleSuffix, $name, $instructions, $tab)
     {
         $fieldsService = Craft::$app->getFields();
 
@@ -120,7 +86,6 @@ class OrderService extends Component
         $field = $fieldsService->getFieldByHandle($fieldHandle);
         if (!$field) {
             $field = new PlainText([
-                'groupId' => $fieldGroup->id,
                 'name' => $name,
                 'handle' => $fieldHandle,
                 'instructions' => $instructions,
@@ -133,6 +98,7 @@ class OrderService extends Component
             }
         }
 
+        // Add the field to the tab
         $this->addFieldToTab($field, $tab, Order::class);
     }
 
@@ -140,7 +106,7 @@ class OrderService extends Component
      * Adds a field to a tab in a field layout for a specific element type.
      *
      * @param Field $field The field to be added.
-     * @param Tab $tab The tab in the field layout to add the field to.
+     * @param FieldLayoutTab $tab The tab in the field layout to add the field to.
      * @param string $elementType The type of element the field layout is for.
      * @return bool Whether the field was successfully added to the tab.
     */

--- a/src/shipping/ClickAndCollectShippingMethod.php
+++ b/src/shipping/ClickAndCollectShippingMethod.php
@@ -13,17 +13,23 @@
 
 namespace burnthebook\craftcommerceclickandcollect\shipping;
 
+use craft\commerce\elements\Order;
+use Illuminate\Support\Collection;
 use craft\commerce\base\ShippingRuleInterface;
 use craft\commerce\base\ShippingMethodInterface;
 use craft\commerce\base\ShippingMethod as BaseShippingMethod;
-use craft\commerce\elements\Order;
 
-class ClickAndCollectShippingMethod extends BaseShippingMethod implements ShippingMethodInterface
+class ClickAndCollectShippingMethod implements ShippingMethodInterface
 {
     /**
      * @var int|null ID
      */
     public ?int $id = null;
+
+    /**
+     * @var int|null Store ID
+     */
+    // public ?int $storeId = null;
 
     /**
      * @var string|null Name
@@ -39,6 +45,15 @@ class ClickAndCollectShippingMethod extends BaseShippingMethod implements Shippi
      * @var bool Enabled
      */
     public bool $enabled = true;
+
+    /**
+     * Returns the type of Shipping Method. This might be the name of the plugin or provider.
+     * The core shipping methods have type: `Custom`. This is shown in the control panel only.
+     */
+    public function getType(): string
+    {
+        return $this->name;
+    }
 
     /**
      * Returns the ID of the current object.
@@ -68,6 +83,15 @@ class ClickAndCollectShippingMethod extends BaseShippingMethod implements Shippi
     public function getHandle(): string
     {
         return $this->handle;
+    }
+
+    /**
+     * Returns the control panel URL to manage this method and its rules.
+     * An empty string will result in no link.
+     */
+    public function getCpEditUrl(): string
+    {
+        return '';
     }
 
     /**
@@ -120,4 +144,29 @@ class ClickAndCollectShippingMethod extends BaseShippingMethod implements Shippi
     {
         return [new ClickAndCollectShippingRule()];
     }
+
+    /**
+     * Returns an array of rules that meet the `ShippingRules` interface.
+     *
+     * @return Collection<ShippingRuleInterface> The array of ShippingRules
+     */
+    public function getShippingRules(): Collection
+    {
+        return new Collection([new ClickAndCollectShippingRule()]);
+    }
+
+
+    public function getPriceForOrder(Order $order): float
+    {
+        return 0;
+    }
+
+    /**
+     * The first matching shipping rule for this shipping method
+     */
+    public function getMatchingShippingRule(Order $order): ?ShippingRuleInterface
+    {
+        return new ClickAndCollectShippingRule();
+    }
+
 }

--- a/src/shipping/ClickAndCollectShippingRule.php
+++ b/src/shipping/ClickAndCollectShippingRule.php
@@ -13,7 +13,7 @@
 
 namespace burnthebook\craftcommerceclickandcollect\shipping;
 
-use craft\commerce\base\Model as BaseShippingRule;
+use craft\commerce\models\ShippingRule as BaseShippingRule;
 use craft\commerce\base\ShippingRuleInterface;
 use craft\commerce\elements\Order;
 
@@ -43,9 +43,9 @@ class ClickAndCollectShippingRule extends BaseShippingRule implements ShippingRu
     /**
      * Returns the options for this object.
      *
-     * @return mixed The attributes for this object.
+     * @return array The attributes for this object.
      */
-    public function getOptions(): mixed
+    public function getOptions(): array
     {
         return $this->getAttributes();
     }
@@ -56,7 +56,7 @@ class ClickAndCollectShippingRule extends BaseShippingRule implements ShippingRu
      * @param string $shippingCategory The shipping category to get the percentage rate for.
      * @return float The percentage rate for the given shipping category.
      */
-    public function getPercentageRate($shippingCategory): float
+    public function getPercentageRate(?int $shippingCategoryId = null): float
     {
         return 0;
     }
@@ -67,7 +67,7 @@ class ClickAndCollectShippingRule extends BaseShippingRule implements ShippingRu
      * @param string $shippingCategory The category of the item being shipped.
      * @return float The per item shipping rate.
      */
-    public function getPerItemRate($shippingCategory): float
+    public function getPerItemRate(?int $shippingCategoryId = null): float
     {
         return 0;
     }
@@ -78,7 +78,7 @@ class ClickAndCollectShippingRule extends BaseShippingRule implements ShippingRu
      * @param string $shippingCategory The category of the shipment.
      * @return float The weight rate for the given shipping category.
      */
-    public function getWeightRate($shippingCategory): float
+    public function getWeightRate(?int $shippingCategoryId = null): float
     {
         return 0;
     }


### PR DESCRIPTION

Adds Craft CMS 5.x and Commerce 5.x Support

OrderService changes:

| Deprecation                           | Reason                                                 |
| ------------------------------------- | ------------------------------------------------------ |
| OrderService::createGroup() Removed   | Field Groups no longer exist in Craft 5.               |
| OrderService::createField() Updated   | Fields are created without groups.                     |
| OrderService::createTab() Updated     | Tabs are still part of Field Layouts so they are kept. |
| OrderService::addFieldToTab() Updated | This has been adjusted to work without Field Groups.   |

ClickAndCollectShippingRule updated to use `craft\commerce\models\ShippingRule`. Stricter type hints implemented.
